### PR TITLE
Fix cannot specify security group

### DIFF
--- a/conoha/conoha.py
+++ b/conoha/conoha.py
@@ -297,15 +297,11 @@ def create(imageid, flavorid, password, name, key, groupNames):
             "adminPass": password,
             "metadata": {}
         }
-    } 
+    }
 
     if name: payload["server"]['metadata']['instance_name_tag'] = name
     if key: payload['server']['key_name'] = key
-
-    if groupNames:
-        payload['server']['security_groups'] = []
-        for name in groupNames:
-            payload['server']['security_groups'].append({ 'name': name, })
+    if groupNames: payload['server']['security_groups'] = [{ 'name': groupNames }]
 
     r = requests.post(url, headers=headers, data=json.dumps(payload))
 


### PR DESCRIPTION
Thank you for an awesome tool :)

I fixed a bug that we cannot specify `security group` when we execute `$ conoha compute vm create`.

For example:
```bash
$ conoha compute vm create --imageid 2322444e-9000-47a8-a425-45fdef52d031 --flavorid d92b02ce-9a4f-4544-8d7f-ae8380bc08e7 --password 'PASSWORD_DESU' --key KAGI_DESU --name SERVER_NO_NAME_DESU --group-names gncs-ipv4-all
{"badRequest":{"message":"Unable to find security_group with name g","code":400}}
```

In python code, `groupNames` is assigned `gncs-ipv4-all` as `type=str` (Do you assume `array`?). Therefore when `for ... in ...` is used `groupNames` is divided each string such as `g`, `n`, `c`, `s`, `-`....

So I fixed it.